### PR TITLE
Separate NavBar and NavBarButton border radius settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+## 6.1.0
+
+* Allow configuring border radius separately for the navigation bar container and its buttons
+
 ## 6.0.0
 
-* BREAKING: Upgrade minimum Flutter version to 3.29 due to using Color.withValues() 
+* BREAKING: Upgrade minimum Flutter version to 3.29 due to using Color.withValues()
 * Update Android tooling
 
 ## 5.1.0

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 * Optional: Change the opacity (`backgroundOpacity`) of the menu bar
 * Optional: Blurred background (`backgroundBlur`) from the top of the navigation bar to the bottom of the screen
 * By default shows text on selected button (and resizes all buttons), this can simply be disabled via: `showActiveButtonText = false`
+* Configure border radius for the navigation bar container and its buttons separately
 * Only StatelessWidgets
 
 * How to make the `bottomNavigationBar` float above the `Scaffold`'s body:

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -29,6 +29,8 @@ class _MyAppState extends State<MyApp> {
         bottomNavigationBar: ResponsiveNavigationBar(
           selectedIndex: _selectedIndex,
           onTabChange: changeTab,
+          navigationBarBorderRadius: 12,
+          navigationBarButtonBorderRadius: 18,
           // showActiveButtonText: false,
           textStyle: const TextStyle(
             color: Colors.white,

--- a/lib/responsive_navigation_bar.dart
+++ b/lib/responsive_navigation_bar.dart
@@ -14,6 +14,8 @@ class ResponsiveNavigationBar extends StatelessWidget {
     this.backgroundOpacity = 0.5,
     this.backgroundBlur = 2.5,
     this.borderRadius = 80,
+    this.navigationBarBorderRadius,
+    this.navigationBarButtonBorderRadius,
     this.padding = const EdgeInsets.all(6),
     this.outerPadding = const EdgeInsets.fromLTRB(8, 0, 8, 5),
     this.selectedIndex = 0,
@@ -74,8 +76,18 @@ class ResponsiveNavigationBar extends StatelessWidget {
   /// Defaults to 2.5
   final double backgroundBlur;
 
-  /// BorderRadius of all elements
+  /// BorderRadius fallback for both the navigation bar and its buttons.
   final double borderRadius;
+
+  /// BorderRadius of the navigation bar container.
+  ///
+  /// Defaults to [borderRadius] when null.
+  final double? navigationBarBorderRadius;
+
+  /// BorderRadius of the navigation bar buttons.
+  ///
+  /// Defaults to [borderRadius] when null.
+  final double? navigationBarButtonBorderRadius;
 
   /// Padding of the bar inside [backgroundColor]
   final EdgeInsetsGeometry padding;
@@ -173,6 +185,10 @@ class ResponsiveNavigationBar extends StatelessWidget {
                 ? 20
                 : 18);
 
+    final navigationBarRadius = navigationBarBorderRadius ?? borderRadius;
+    final navigationBarButtonRadius =
+        navigationBarButtonBorderRadius ?? borderRadius;
+
     final buttons = <Widget>[];
     for (final button in navigationBarButtons) {
       final index = navigationBarButtons.indexOf(button);
@@ -189,7 +205,7 @@ class ResponsiveNavigationBar extends StatelessWidget {
           activeIconColor: activeIconColor,
           inactiveIconColor: inactiveIconColor,
           animationDuration: animationDuration,
-          borderRadius: borderRadius,
+          buttonBorderRadius: navigationBarButtonRadius,
           padding: button.padding ??
               (deviceWidth >= 650
                   ? const EdgeInsets.symmetric(horizontal: 30, vertical: 10)
@@ -226,7 +242,7 @@ class ResponsiveNavigationBar extends StatelessWidget {
                       : null,
                   gradient: backgroundGradient,
                   borderRadius: BorderRadius.all(
-                    Radius.circular(borderRadius),
+                    Radius.circular(navigationBarRadius),
                   ),
                 ),
                 child: Padding(
@@ -305,7 +321,7 @@ class _Button extends StatelessWidget {
     required this.activeIconColor,
     required this.inactiveIconColor,
     required this.animationDuration,
-    required this.borderRadius,
+    required this.buttonBorderRadius,
     required this.padding,
     required this.backgroundColor,
     required this.backgroundGradient,
@@ -326,7 +342,7 @@ class _Button extends StatelessWidget {
   final Color activeIconColor;
   final Color inactiveIconColor;
   final Duration animationDuration;
-  final double borderRadius;
+  final double buttonBorderRadius;
   final EdgeInsetsGeometry padding;
   final Color backgroundColor;
   final Gradient? backgroundGradient;
@@ -371,7 +387,7 @@ class _Button extends StatelessWidget {
               return DecoratedBox(
                 decoration: BoxDecoration(
                   borderRadius: BorderRadius.all(
-                    Radius.circular(borderRadius),
+                    Radius.circular(buttonBorderRadius),
                   ),
                   gradient: backgroundGradient,
                   color: color,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ topics:
   - responsive
   - ui
 
-version: 6.0.0
+version: 6.1.0
 
 environment:
   sdk: '>=3.6.0 <4.0.0'


### PR DESCRIPTION
## Summary
- add individual border radius configuration for the navigation bar container and its buttons while keeping the existing borderRadius as a fallback
- update example usage and documentation to highlight the new customization
- bump package version and changelog for the new feature

## Testing
- not run (dart/flutter tooling not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691930d6da548332bd4bfa4a51b5665c)