### PR TITLE
Support AGP 9 example compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.2.1
+
+* Update the example Android toolchain to Android Gradle Plugin 9.1.1, Gradle 9.3.1, and Kotlin Gradle Plugin 2.2.20.
+* Apply the example app's Kotlin Gradle Plugin only when the host build still needs it.
 ## 6.2.0
 
 * Add `iconSize` parameter to `ResponsiveNavigationBar` for independent control of icon size

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -1,9 +1,22 @@
 plugins {
     id "com.android.application"
-    id "org.jetbrains.kotlin.android"
-    // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
-    id "dev.flutter.flutter-gradle-plugin"
 }
+
+def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
+boolean hasBuiltInKotlinSupport = agpMajor >= 9
+
+def builtInKotlinProperty = findProperty('android.builtInKotlin')
+boolean isBuiltInKotlinEnabled = builtInKotlinProperty == null ||
+        builtInKotlinProperty.toString().toBoolean()
+
+boolean shouldApplyKotlinGradlePlugin = !hasBuiltInKotlinSupport || !isBuiltInKotlinEnabled
+
+if (shouldApplyKotlinGradlePlugin) {
+    apply plugin: 'org.jetbrains.kotlin.android'
+}
+
+// The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
+apply plugin: "dev.flutter.flutter-gradle-plugin"
 
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file("local.properties")
@@ -33,10 +46,6 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
-    kotlinOptions {
-        jvmTarget = "17"
-    }
-
     defaultConfig {
         applicationId "com.responsive_navigation_bar.example"
         // You can update the following values to match your application needs.
@@ -58,4 +67,10 @@ android {
 
 flutter {
     source = "../.."
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+    }
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Jun 05 09:15:37 WEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.7.2" apply false
-    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
+    id "com.android.application" version "9.1.1" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 
 include ":app"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -137,7 +137,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "6.1.0"
+    version: "6.2.1"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ topics:
   - responsive
   - ui
 
-version: 6.2.0
+version: 6.2.1
 
 environment:
   sdk: '>=3.6.0 <4.0.0'


### PR DESCRIPTION
## Summary
- update the example to AGP 9.1.1, Gradle 9.3.1, and Kotlin 2.2.20
- support both AGP 9 built-in Kotlin and the legacy Kotlin plugin fallback
- bump the package to 6.2.1

## Validation
- AGP 9 legacy and built-in Kotlin builds
- Flutter package and example tests
- APK build and publish dry-run